### PR TITLE
Fix nuget dependencies

### DIFF
--- a/src/StackExchange.Redis.Extensions.Data/Properties/AssemblyInfo.cs
+++ b/src/StackExchange.Redis.Extensions.Data/Properties/AssemblyInfo.cs
@@ -2,7 +2,7 @@
 using System.Resources;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
+// General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("StackExchange.Redis.Extensions.Data")]
@@ -12,8 +12,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright © Richard Murillo 2015")]
 [assembly: NeutralResourcesLanguage("en")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
@@ -23,13 +23,13 @@ using System.Runtime.InteropServices;
 // Version information for an assembly consists of the following four values:
 //
 //      Major Version
-//      Minor Version 
+//      Minor Version
 //      Build Number
 //      Revision
 //
-// You can specify all the values or you can default the Build and Revision Numbers 
+// You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
-
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyInformationalVersion("1.1.0")]

--- a/src/StackExchange.Redis.Extensions.Data/StackExchange.Redis.Extensions.Data.csproj
+++ b/src/StackExchange.Redis.Extensions.Data/StackExchange.Redis.Extensions.Data.csproj
@@ -32,28 +32,19 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
     <Reference Include="StackExchange.Redis, Version=1.0.316.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\StackExchange.Redis.1.0.394\lib\net45\StackExchange.Redis.dll</HintPath>
+      <HintPath>..\..\packages\StackExchange.Redis.1.0.488\lib\net45\StackExchange.Redis.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="StackExchange.Redis.Extensions.Core, Version=1.1.7.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\StackExchange.Redis.Extensions.Core.1.1.7.0\lib\net45\StackExchange.Redis.Extensions.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="StackExchange.Redis.Extensions.Newtonsoft, Version=1.1.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\StackExchange.Redis.Extensions.Newtonsoft.1.1.4.0\lib\net45\StackExchange.Redis.Extensions.Newtonsoft.dll</HintPath>
+    <Reference Include="StackExchange.Redis.Extensions.Core, Version=1.1.14.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\StackExchange.Redis.Extensions.Core.1.1.14.0\lib\net45\StackExchange.Redis.Extensions.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/src/StackExchange.Redis.Extensions.Data/StackExchange.Redis.Extensions.Data.nuspec
+++ b/src/StackExchange.Redis.Extensions.Data/StackExchange.Redis.Extensions.Data.nuspec
@@ -21,5 +21,17 @@
         <copyright>Richard Murillo</copyright>
         <language>en-US</language>
         <tags>Async Redis NoSQL Client Distributed Cache PubSub Messaging</tags>
+        <dependencies>
+            <dependency id="StackExchange.Redis.Extensions.Core" version="1.1.14" />
+        </dependencies>
+        <frameworkAssemblies>
+            <frameworkAssembly assemblyName="System" />
+            <frameworkAssembly assemblyName="System.ComponentModel.DataAnnotations" />
+            <frameworkAssembly assemblyName="System.Core" />
+            <frameworkAssembly assemblyName="System.Data" />
+            <frameworkAssembly assemblyName="System.Data.DataSetExtensions" />
+            <frameworkAssembly assemblyName="System.Xml" />
+            <frameworkAssembly assemblyName="System.Xml.Linq" />
+        </frameworkAssemblies>
     </metadata>
 </package>

--- a/src/StackExchange.Redis.Extensions.Data/StackExchange.Redis.Extensions.Data.nuspec
+++ b/src/StackExchange.Redis.Extensions.Data/StackExchange.Redis.Extensions.Data.nuspec
@@ -6,8 +6,8 @@
         <version>$version$</version>
         <authors>$author$</authors>
         <owners>$author$</owners>
-        <licenseUrl>https://github.com/rjmurillo/SimpleRedisGraph/blob/master/LICENSE</licenseUrl>
-        <projectUrl>https://github.com/rjmurillo/SimpleRedisGraph</projectUrl>
+        <licenseUrl>https://github.com/LeCantaloop/StackExchange.Redis.Extensions.Data/blob/master/LICENSE</licenseUrl>
+        <projectUrl>https://github.com/LeCantaloop/StackExchange.Redis.Extensions.Data</projectUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>
             Extends StackExchange.Redis.Extensions allowing implementation of object relationships, storage of object properties as hashes, and implementing a Repository pattern.

--- a/src/StackExchange.Redis.Extensions.Data/packages.config
+++ b/src/StackExchange.Redis.Extensions.Data/packages.config
@@ -1,7 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
-  <package id="StackExchange.Redis" version="1.0.394" targetFramework="net45" />
-  <package id="StackExchange.Redis.Extensions.Core" version="1.1.7.0" targetFramework="net45" />
-  <package id="StackExchange.Redis.Extensions.Newtonsoft" version="1.1.4.0" targetFramework="net45" />
+  <package id="StackExchange.Redis" version="1.0.488" targetFramework="net45" />
+  <package id="StackExchange.Redis.Extensions.Core" version="1.1.14.0" targetFramework="net45" />
 </packages>

--- a/src/StackExchange.Redis.Extensions.Data/readme.md
+++ b/src/StackExchange.Redis.Extensions.Data/readme.md
@@ -10,7 +10,7 @@
             {
                 if (_clientManager == null)
                 {
-                    var s = new JsonSerializer();
+                    var s = new NewtonsoftSerializer();
                     try
                     {
                         var configurationOptions = new ConfigurationOptions

--- a/tests/StackExchange.Redis.Extensions.Data.Tests/RedisRepositoryTests.cs
+++ b/tests/StackExchange.Redis.Extensions.Data.Tests/RedisRepositoryTests.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using StackExchange.Redis.Extensions.Core;
+using StackExchange.Redis.Extensions.Newtonsoft;
 
 namespace StackExchange.Redis.Extensions.Data.Tests
 {
@@ -87,12 +88,13 @@ namespace StackExchange.Redis.Extensions.Data.Tests
 
         private class MockCacheClient : ICacheClient
         {
-            private MockDatabase _db;
+            private readonly MockDatabase _db;
+            private readonly NewtonsoftSerializer _serializer;
 
             public MockCacheClient()
             {
                 _db = new MockDatabase();
-                _serializer = new StackExchange.Redis.Extensions.Newtonsoft.JsonSerializer();
+                _serializer = new NewtonsoftSerializer();
             }
 
             public void Dispose()
@@ -128,112 +130,121 @@ namespace StackExchange.Redis.Extensions.Data.Tests
                 return null;
             }
 
-            public T Get<T>(string key) where T : class
+            public T Get<T>(string key)
+            {
+                return default(T);
+            }
+
+            public Task<T> GetAsync<T>(string key)
             {
                 return null;
             }
 
-            public Task<T> GetAsync<T>(string key) where T : class
-            {
-                return null;
-            }
-
-            public bool Add<T>(string key, T value) where T : class
+            public bool Add<T>(string key, T value)
             {
                 Debug.WriteLine(key + " : " + value);
                 Database.StringSet(key, Serializer.Serialize(value));
-               
+
                 return true;
             }
 
-            public Task<bool> AddAsync<T>(string key, T value) where T : class
+            public Task<bool> AddAsync<T>(string key, T value)
             {
                 return null;
             }
 
-            public bool Replace<T>(string key, T value) where T : class
+            public bool Replace<T>(string key, T value)
             {
                 return false;
             }
 
-            public Task<bool> ReplaceAsync<T>(string key, T value) where T : class
+            public Task<bool> ReplaceAsync<T>(string key, T value)
             {
                 return null;
             }
 
-            public bool Add<T>(string key, T value, DateTimeOffset expiresAt) where T : class
+            public bool Add<T>(string key, T value, DateTimeOffset expiresAt)
             {
                 return false;
             }
 
-            public Task<bool> AddAsync<T>(string key, T value, DateTimeOffset expiresAt) where T : class
+            public Task<bool> AddAsync<T>(string key, T value, DateTimeOffset expiresAt)
             {
                 return null;
             }
 
-            public bool Replace<T>(string key, T value, DateTimeOffset expiresAt) where T : class
+            public bool Replace<T>(string key, T value, DateTimeOffset expiresAt)
             {
                 return false;
             }
 
-            public Task<bool> ReplaceAsync<T>(string key, T value, DateTimeOffset expiresAt) where T : class
+            public Task<bool> ReplaceAsync<T>(string key, T value, DateTimeOffset expiresAt)
             {
                 return null;
             }
 
-            public bool Add<T>(string key, T value, TimeSpan expiresIn) where T : class
+            public bool Add<T>(string key, T value, TimeSpan expiresIn)
             {
                 return false;
             }
 
-            public Task<bool> AddAsync<T>(string key, T value, TimeSpan expiresIn) where T : class
+            public Task<bool> AddAsync<T>(string key, T value, TimeSpan expiresIn)
             {
                 return null;
             }
 
-            public bool Replace<T>(string key, T value, TimeSpan expiresIn) where T : class
+            public bool Replace<T>(string key, T value, TimeSpan expiresIn)
             {
                 return false;
             }
 
-            public Task<bool> ReplaceAsync<T>(string key, T value, TimeSpan expiresIn) where T : class
+            public Task<bool> ReplaceAsync<T>(string key, T value, TimeSpan expiresIn)
             {
                 return null;
             }
 
-            public IDictionary<string, T> GetAll<T>(IEnumerable<string> keys) where T : class
+            public IDictionary<string, T> GetAll<T>(IEnumerable<string> keys)
             {
                 return null;
             }
 
-            public Task<IDictionary<string, T>> GetAllAsync<T>(IEnumerable<string> keys) where T : class
+            public Task<IDictionary<string, T>> GetAllAsync<T>(IEnumerable<string> keys)
             {
                 return null;
             }
 
-            public bool AddAll<T>(IList<Tuple<string, T>> items) where T : class
+            public bool AddAll<T>(IList<Tuple<string, T>> items)
             {
                 return false;
             }
 
-            public Task<bool> AddAllAsync<T>(IList<Tuple<string, T>> items) where T : class
+            public Task<bool> AddAllAsync<T>(IList<Tuple<string, T>> items)
             {
                 return null;
             }
 
- 
-            private StackExchange.Redis.Extensions.Newtonsoft.JsonSerializer _serializer;
+
 
             public bool SetAdd(string memberName, string key)
             {
                 Database.SetAdd(memberName, key);
-               
+
                 return true;
             }
 
             public Task<bool> SetAddAsync(string memberName, string key)
             {
                 return null;
+            }
+
+            public bool SetAdd<T>(string key, T item) where T : class
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task<bool> SetAddAsync<T>(string key, T item) where T : class
+            {
+                throw new NotImplementedException();
             }
 
             public string[] SetMember(string memberName)
@@ -265,6 +276,16 @@ namespace StackExchange.Redis.Extensions.Data.Tests
                 return null;
             }
 
+            public void Save(SaveType saveType)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void SaveAsync(SaveType saveType)
+            {
+                throw new NotImplementedException();
+            }
+
             public Dictionary<string, string> GetInfo()
             {
                 return null;
@@ -273,6 +294,66 @@ namespace StackExchange.Redis.Extensions.Data.Tests
             public Task<Dictionary<string, string>> GetInfoAsync()
             {
                 return null;
+            }
+
+            public long Publish<T>(RedisChannel channel, T message, CommandFlags flags = CommandFlags.None)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task<long> PublishAsync<T>(RedisChannel channel, T message, CommandFlags flags = CommandFlags.None)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Subscribe<T>(RedisChannel channel, Action<T> handler, CommandFlags flags = CommandFlags.None)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task SubscribeAsync<T>(RedisChannel channel, Func<T, Task> handler, CommandFlags flags = CommandFlags.None)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void Unsubscribe<T>(RedisChannel channel, Action<T> handler, CommandFlags flags = CommandFlags.None)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task UnsubscribeAsync<T>(RedisChannel channel, Func<T, Task> handler, CommandFlags flags = CommandFlags.None)
+            {
+                throw new NotImplementedException();
+            }
+
+            public void UnsubscribeAll(CommandFlags flags = CommandFlags.None)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task UnsubscribeAllAsync(CommandFlags flags = CommandFlags.None)
+            {
+                throw new NotImplementedException();
+            }
+
+            public long ListAddToLeft<T>(string key, T item) where T : class
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task<long> ListAddToLeftAsync<T>(string key, T item) where T : class
+            {
+                throw new NotImplementedException();
+            }
+
+            public T ListGetFromRight<T>(string key) where T : class
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task<T> ListGetFromRightAsync<T>(string key) where T : class
+            {
+                throw new NotImplementedException();
             }
 
             public StackExchange.Redis.IDatabase Database
@@ -619,6 +700,16 @@ namespace StackExchange.Redis.Extensions.Data.Tests
                 public Task<RedisResult> ScriptEvaluateAsync(byte[] hash, RedisKey[] keys = null, RedisValue[] values = null, CommandFlags flags = CommandFlags.None)
                 {
                     return null;
+                }
+
+                public Task<RedisResult> ScriptEvaluateAsync(LuaScript script, object parameters = null, CommandFlags flags = CommandFlags.None)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public Task<RedisResult> ScriptEvaluateAsync(LoadedLuaScript script, object parameters = null, CommandFlags flags = CommandFlags.None)
+                {
+                    throw new NotImplementedException();
                 }
 
                 public Task<bool> SetAddAsync(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None)
@@ -1235,6 +1326,16 @@ namespace StackExchange.Redis.Extensions.Data.Tests
                     return null;
                 }
 
+                public RedisResult ScriptEvaluate(LuaScript script, object parameters = null, CommandFlags flags = CommandFlags.None)
+                {
+                    throw new NotImplementedException();
+                }
+
+                public RedisResult ScriptEvaluate(LoadedLuaScript script, object parameters = null, CommandFlags flags = CommandFlags.None)
+                {
+                    throw new NotImplementedException();
+                }
+
                 public bool SetAdd(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None)
                 {
                     Debug.WriteLine(key.ToString() + " : " + value);
@@ -1268,7 +1369,7 @@ namespace StackExchange.Redis.Extensions.Data.Tests
                     return 0;
                 }
 
-                Dictionary<RedisKey,RedisValue[]> _set = new Dictionary<RedisKey, RedisValue[]>(); 
+                Dictionary<RedisKey,RedisValue[]> _set = new Dictionary<RedisKey, RedisValue[]>();
 
                 public bool SetContains(RedisKey key, RedisValue value, CommandFlags flags = CommandFlags.None)
                 {

--- a/tests/StackExchange.Redis.Extensions.Data.Tests/StackExchange.Redis.Extensions.Data.Tests.csproj
+++ b/tests/StackExchange.Redis.Extensions.Data.Tests/StackExchange.Redis.Extensions.Data.Tests.csproj
@@ -37,21 +37,21 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="StackExchange.Redis, Version=1.0.316.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\StackExchange.Redis.1.0.394\lib\net45\StackExchange.Redis.dll</HintPath>
+      <HintPath>..\..\packages\StackExchange.Redis.1.0.488\lib\net45\StackExchange.Redis.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="StackExchange.Redis.Extensions.Core, Version=1.1.7.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\StackExchange.Redis.Extensions.Core.1.1.7.0\lib\net45\StackExchange.Redis.Extensions.Core.dll</HintPath>
+    <Reference Include="StackExchange.Redis.Extensions.Core, Version=1.1.14.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\StackExchange.Redis.Extensions.Core.1.1.14.0\lib\net45\StackExchange.Redis.Extensions.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="StackExchange.Redis.Extensions.Newtonsoft, Version=1.1.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\StackExchange.Redis.Extensions.Newtonsoft.1.1.4.0\lib\net45\StackExchange.Redis.Extensions.Newtonsoft.dll</HintPath>
+    <Reference Include="StackExchange.Redis.Extensions.Newtonsoft, Version=1.1.11.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\StackExchange.Redis.Extensions.Newtonsoft.1.1.11.0\lib\net45\StackExchange.Redis.Extensions.Newtonsoft.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/tests/StackExchange.Redis.Extensions.Data.Tests/packages.config
+++ b/tests/StackExchange.Redis.Extensions.Data.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
-  <package id="StackExchange.Redis" version="1.0.394" targetFramework="net45" />
-  <package id="StackExchange.Redis.Extensions.Core" version="1.1.7.0" targetFramework="net45" />
-  <package id="StackExchange.Redis.Extensions.Newtonsoft" version="1.1.4.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="StackExchange.Redis" version="1.0.488" targetFramework="net45" />
+  <package id="StackExchange.Redis.Extensions.Core" version="1.1.14.0" targetFramework="net45" />
+  <package id="StackExchange.Redis.Extensions.Newtonsoft" version="1.1.11.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
- The StackExchange.Redis.Extensions project had a breaking change in the Netwonsoft serializer / deserializer. Update our dependencies so we don't support before the breaking change.
  - Use the nuspec file to enforce the versioning
- Add framework dependencies to .nuspec file
- Update docs
